### PR TITLE
Make va default i18n-tasks language & add es

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,9 +1,9 @@
 # i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
 
 # The "main" locale.
-base_locale: en
+base_locale: va
 ## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
-locales: [en, va]
+locales: [va, es]
 ## Reporting locale, default: en. Available: en, ru.
 # internal_locale: en
 


### PR DESCRIPTION
When running the `spec/i18n_spec.rb` spec you'll get better support about both languages