### PR TITLE
Fix Valencian lang code from `va` to `val`

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,9 +1,9 @@
 # i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
 
 # The "main" locale.
-base_locale: va
+base_locale: val
 ## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
-locales: [va, es]
+locales: [val, es]
 ## Reporting locale, default: en. Available: en, ru.
 # internal_locale: en
 


### PR DESCRIPTION
I didn't realize valencian locale code is `val` instead of `va` :( I assumed based in existing `:va` my mistake!